### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/raabro.gemspec
+++ b/raabro.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux+flor@gmail.com' ]
   s.homepage = 'http://github.com/floraison/raabro'
-  #s.rubyforge_project = 'rufus'
   s.license = 'MIT'
   s.summary = 'a very dumb PEG parser library'
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.