### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ branches:
   #except:
   #  - master
 
-sudo: false
 cache: bundler
 


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).