### PR TITLE
Replace regex with `start_with?`

### DIFF
--- a/lib/raabro.rb
+++ b/lib/raabro.rb
@@ -565,7 +565,7 @@ module Raabro
 
     def rewrite(tree)
 
-      return !! methods.find { |m| m.to_s.match?(/^rewrite_/) } if tree == 0
+      return !! methods.find { |m| m.to_s.start_with?("rewrite_") } if tree == 0
         # return true when "rewrite_xxx" methods seem to have been provided
 
       send("rewrite_#{tree.name}", tree)


### PR DESCRIPTION
Saw this when upgrading our deps.

The stated goal was an optimisation, and this is likely faster than a regex (but I haven't measured). Also arguably clearer.

(On a side note, `\A` is recommended over `^` when "beginning of string" is intended – might have performance implications, and will in some situations have important security implications – though not here 🙂)